### PR TITLE
Elastic training

### DIFF
--- a/elastic/README.md
+++ b/elastic/README.md
@@ -1,0 +1,46 @@
+# Provision training environment
+
+This is the repository to provision the training environment for the NLP training.
+
+## Prerequisites
+
+You need to have the [gcloud CLI](https://cloud.google.com/sdk/downloads) installed.
+You need to be authenticated (`gcloud auth login`) and to have chosen the correct Google Cloud project (`gcloud config set project <project_id>`).
+Note: make sure to use the `project_id` and not the `project_name`.
+
+You need a Python 3 interpreter and install the following packages (`pip` suffices):
+
+- `click`
+- `delegator.py` (note: don't use `pip install delegator`)
+- `pyyaml`
+- `ansible`
+
+
+## Usage
+
+Remember to put the
+
+- The list of users into `var/common.yml`, under `users`;
+- The notebooks in `roles/conda/files/notebooks`.
+
+Then execute:
+
+```bash
+export PROJECT_ID=my-project  # you can skip it if it's configured in your gcloud default values
+python deploy-elastic.py --instances <num_instances> [optional: --name <name-prefix>] 
+ansible-playbook -i elastic-hosts --private-key gcloud_elastic_ansible playbook-elastic.yml
+```
+
+You should be good to go now!
+
+## Access
+
+To SSH into the machine and set up port forwarding:
+
+```bash
+ssh -i gcloud_ansible -o IdentitiesOnly=yes <my_user>@<instance_external_ip>
+```
+
+The `instance_external_ip` can be found in the `elastic-hosts` file.
+
+Ports 9200, 5601, 10000 and 5000 are opened up to access Elasticsearch, Kibana, Netcat and Jupyter, respectively.

--- a/elastic/README.md
+++ b/elastic/README.md
@@ -21,7 +21,9 @@ You need a Python 3 interpreter and install the following packages (`pip` suffic
 Remember to put the
 
 - The list of users into `var/common.yml`, under `users`;
-- The notebooks in `roles/conda/files/notebooks`.
+- The notebooks in `roles/conda/files/notebooks`
+
+Be aware that the ansible script expects one of the folders you save in `roles/conda/files/notebooks` to be called `exercises/`; the script will set a subdirectory called `data/` with all of the necessary files in `exercises/`. 
 
 Then execute:
 
@@ -43,4 +45,14 @@ ssh -i gcloud_ansible -o IdentitiesOnly=yes <my_user>@<instance_external_ip>
 
 The `instance_external_ip` can be found in the `elastic-hosts` file.
 
-Ports 9200, 5601, 10000 and 5000 are opened up to access Elasticsearch, Kibana, Netcat and Jupyter, respectively.
+Ports 9200, 5601, and 5000 are opened up to access Elasticsearch, Kibana, and Jupyter, respectively, and ports 10000 and 5044 are opened for internal use by Netcat and Filebeat.
+
+Be aware that only the Wibaut IP address is whitelisted in the firewall settings! To give this training in another location (or to access the GCEs from home, say), after creating your GCEs do the following in the Google Cloud Console:
+
++ navigate to `VPC Network` -> `Firewall rules`
++ click on `allow-elastic-training-ports`
++ click on `Edit`
++ add the desired IP address under `Source IP ranges`
++ click on `Save`
+
+Be aware that the following time you run `deploy-elastic.py`, these added IP addresses will be removed.  

--- a/elastic/ansible.cfg
+++ b/elastic/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+host_key_checking = False
+
+[ssh_connection]
+ssh_args = -o IdentitiesOnly=yes

--- a/elastic/deploy-elastic.py
+++ b/elastic/deploy-elastic.py
@@ -117,10 +117,10 @@ def create_machines(project_id, name_prefix, instances):
     for instance in range(0,instances):
     	machine_name = f"{name_prefix}-{instance}"
     	to_run = f"""gcloud beta compute instances create {machine_name} 
-    	--subnet=default --zone=europe-west4-a
+    	--subnet=default --zone=europe-west1-c
     	--machine-type=n1-standard-4
     	--tags elastic-training-instance
-    	--boot-disk-size=10GB --boot-disk-type=pd-standard --boot-disk-device-name={machine_name}
+    	--boot-disk-size=20GB --boot-disk-type=pd-standard --boot-disk-device-name={machine_name}
 		"""
     	# --network-tier=PREMIUM
     	# --maintenance-policy=MIGRATE

--- a/elastic/deploy-elastic.py
+++ b/elastic/deploy-elastic.py
@@ -1,0 +1,162 @@
+#!/bin/env python
+import os
+import sys
+import random
+import logging
+
+import delegator
+import yaml
+import click
+
+KEY_PATH = "gcloud_elastic_ansible"
+KEYS_PATH = 'elastic-keys'
+YAML_PATH = "vars/common.yml"
+HOSTS_PATH = 'elastic-hosts'
+
+class GCloudError(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+def create_key_pair(key_path):
+    if not os.path.isfile(key_path):
+        delegator.run('ssh-keygen -b 2048 -t rsa -f %s -q -N ""' % key_path)
+
+
+def load_yml(path):
+    with open(path, 'r') as f:
+        data = yaml.safe_load(f)
+    return data
+
+
+def load_key(path):
+    with open(path + ".pub", 'r') as f:
+        key = f.read()
+    return key
+
+
+def write_users(yml, key, key_path):
+    with open(key_path, 'w') as f:
+        for user in yml.get('users', []) + [yml.get('deployer')]:
+            f.write(''.join([user, ':', key]))
+
+
+def add_keys_to(instance_tag, key_path, zone):
+    # TODO This method could be optional
+    delegator.run(("gcloud compute instances add-metadata %s "
+                   "--zone=%s --metadata-from-file sshKeys=%s") % (instance_tag, zone, key_path))
+
+def get_ip_of(instance_tag):
+    # TODO This method could be optional
+    c = delegator.run(('gcloud --format="value(networkInterfaces[0].accessConfigs[0].natIP)" '
+                       'compute instances list --filter="name=(%s)"') % instance_tag)
+    external_ip = c.out.strip()
+    if c.err:
+        raise GCloudError(c.err)
+    elif not external_ip:
+        raise GCloudError("No external ip found for instance {}"
+                          .format(instance_tag))
+
+    print("external ip found for instance {}: {}"
+          .format(instance_tag, external_ip))
+    return external_ip
+
+
+def zone_of(instance_tag):
+    c = delegator.run(('gcloud --format="value(zone)" '
+                       'compute instances list %s') % instance_tag)
+    zone = c.out.strip()
+    return zone
+
+def add_firewall_rules():
+    delegator.run("gcloud compute firewall-rules delete allow-elastic-training-ports ")
+    delegator.run(r"""gcloud compute firewall-rules create allow-elastic-training-ports \
+                   --allow tcp:9200,tcp:5601,tcp:5000,tcp:10000 \
+                   --source-ranges 37.17.221.89/32 \
+                   --target-tags elastic-training-instance \
+                   --description 'Allow access to Elasticsearch, Kibana, Logstash, Netcat and Jupyter'""")
+
+def init_host_file(hosts_path):
+    with open(hosts_path, 'w') as f:
+        f.write('[elastic-instances]')
+        f.write('\n')
+
+def write_ip_to(hosts_path, external_ip):
+    with open(hosts_path, 'a') as f:
+        f.write(external_ip)
+        f.write('\n')
+
+
+def get_variables():
+    return (os.environ.get('KEY_PATH', KEY_PATH),
+            os.environ.get('KEYS_PATH', KEYS_PATH),
+            YAML_PATH,
+            HOSTS_PATH)
+
+
+def get_random_id(N_sequence):
+    _id = ''
+    numbers = list(range(10))
+    for _ in range(N_sequence):
+        _id += str(random.choice(numbers))
+    return _id
+
+def get_instance_name_prefix(name, N_sequence=10):
+    if name:
+        return f"elastic-{name}"
+    else:
+        return f"elastic-{get_random_id(N_sequence)}"
+
+
+def create_machines(project_id, name_prefix, instances):
+    # to_run = f"""gcloud dataproc --region europe-west1 clusters create {cluster_name}
+    # --subnet default --zone europe-west1-c
+    # --master-machine-type n1-standard-16 --master-boot-disk-size 100 --num-workers {workers}
+    # --worker-machine-type n1-standard-4 --worker-boot-disk-size 100
+    # --initialization-actions 'gs://gdd-trainings-bucket/install_conda.sh'
+    # """
+    for instance in range(0,instances):
+    	machine_name = f"{name_prefix}-{instance}"
+    	to_run = f"""gcloud beta compute instances create {machine_name} 
+    	--subnet=default --zone=europe-west4-a
+    	--machine-type=n1-standard-4
+    	--tags elastic-training-instance
+    	--boot-disk-size=10GB --boot-disk-type=pd-standard --boot-disk-device-name={machine_name}
+		"""
+    	# --network-tier=PREMIUM
+    	# --maintenance-policy=MIGRATE
+    	# --service-account=787238606102-compute@developer.gserviceaccount.com
+    	# --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append
+    	# --tags=http-server,https-server
+    	# --image=debian-9-stretch-v20180510
+    	# --image-project=debian-cloud 
+    	if project_id:
+        	to_run += f" --project_id {project_id}"
+    	c = delegator.run(to_run.replace('\n', ' '))
+    	if c.err:
+			# don't raise, it's printing to standard error but it's not an error
+        	logging.warning(c.err)
+
+
+@click.command()
+@click.option('--project', default=None, help="Google project")
+@click.option('--instances', default=3, help="Number of instances")
+@click.option('--name', default=None, help="Google instancename prefix")
+def main(project, instances, name):
+    name_prefix = get_instance_name_prefix(name)
+    create_machines(project, name_prefix, instances)
+    add_firewall_rules()
+    key_path, keys_path, yaml_path, hosts_path = get_variables()
+    create_key_pair(key_path)
+    yml = load_yml(yaml_path)
+    key = load_key(key_path)
+    write_users(yml, key, keys_path)
+    init_host_file(hosts_path)
+    for instance in range(0, instances):
+    	instance_tag = f"{name_prefix}-{instance}"
+    	zone = zone_of(instance_tag)
+    	add_keys_to(instance_tag, keys_path, zone)
+    	external_ip = get_ip_of(instance_tag)
+    	write_ip_to(hosts_path, external_ip)
+
+if __name__ == "__main__":
+    main()

--- a/elastic/ping.yml
+++ b/elastic/ping.yml
@@ -1,0 +1,18 @@
+---
+
+- name: Ansible Playbook for Elastic on google-compute-instances
+  hosts: elastic-instances
+  remote_user: "{{ deployer }}"
+  become: yes
+  become_method: sudo
+  vars_files:
+    - vars/common.yml
+  tasks:
+    
+    - ping:
+
+    - name: get ip
+      debug: msg="{{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+
+    - name: get host
+      debug: msg="{{ hostvars[inventory_hostname]['ansible_fqdn'] }}"

--- a/elastic/playbook-elastic.yml
+++ b/elastic/playbook-elastic.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Ansible Playbook for Elastic on google-compute-instances
+  hosts: elastic-instances
+  remote_user: "{{ deployer }}"
+  become: yes
+  become_method: sudo
+  vars_files:
+    - vars/common.yml
+  roles:
+    - bootstrap
+#    - conda
+    - elastic
+

--- a/elastic/playbook-elastic.yml
+++ b/elastic/playbook-elastic.yml
@@ -9,6 +9,6 @@
     - vars/common.yml
   roles:
     - bootstrap
-#    - conda
+    - conda
     - elastic
 

--- a/elastic/roles/bootstrap/tasks/main.yml
+++ b/elastic/roles/bootstrap/tasks/main.yml
@@ -1,0 +1,20 @@
+- name: Install needed packages
+  apt: 
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - bzip2
+    - zip
+    - unzip
+    # - python3-dev
+    - python3-pip
+    - build-essential
+    - gcc
+    - libfreetype6-dev
+    - blt-dev
+    - pkg-config
+    - netcat
+    # - llvm-3.8-dev
+    # - libssl1.0.0
+    - sudo
+

--- a/elastic/roles/conda/tasks/main.yml
+++ b/elastic/roles/conda/tasks/main.yml
@@ -32,12 +32,19 @@
     - "/miniconda/envs/{{ conda_environment_name }}/.jupyter"
     - "{{ logs_folder }}"
 
+- name: copy notebooks
+  copy:
+    src: files/notebooks/
+    dest: "{{ notebook_folder }}"
+    owner: "{{ deployer }}"
+    mode: 0777
+
 - name: Get dataset
   unarchive:
-    src: https://storage.googleapis.com/gdd-trainings-bucket/accelerator-lecture07_nlp-data.tar.gz
+    src: https://storage.googleapis.com/gdd-trainings-bucket/elastic-stack-two-day-data.tar.gz
     remote_src: yes
-    dest: "{{ notebook_folder }}"
-    creates: "{{ notebook_folder }}/data"
+    dest: "{{ notebook_folder }}/exercises"
+    creates: "{{ notebook_folder }}/exercises/data"
 
 - name: Configure jupyter notebook
   template: 
@@ -50,13 +57,6 @@
     src: start-jupyter.sh
     dest: "/miniconda/envs/{{ conda_environment_name }}"
     mode: 0775
-
-- name: copy notebooks
-  copy:
-    src: files/notebooks/
-    dest: "{{ notebook_folder }}"
-    owner: "{{ deployer }}"
-    mode: 0777
 
 - name: Stop jupyter
   shell: pkill jupyter

--- a/elastic/roles/conda/tasks/main.yml
+++ b/elastic/roles/conda/tasks/main.yml
@@ -1,0 +1,67 @@
+- name: Get installer
+  get_url: url=https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh dest=/tmp/ mode=755
+
+# - name: Start with clean slate
+#   file: 
+#     path: "{{ item }}"
+#     state: absent
+#   with_items:
+#     - /miniconda
+
+- name: Execute installer
+  shell: /tmp/Miniconda3-latest-Linux-x86_64.sh -b -p /miniconda creates=/miniconda/bin executable=/bin/bash
+
+- name: Copy environment specs
+  template: src=environment.yml dest=/tmp/ mode=755
+
+- name: Create virtual conda environment
+  shell: "/miniconda/bin/conda env create -f /tmp/environment.yml -p /miniconda/envs/{{ conda_environment_name }}"
+  args:
+    creates: "/miniconda/envs/{{ conda_environment_name }}"
+
+- name: Download english spacy defs
+  shell: "/miniconda/envs/{{ conda_environment_name }}/bin/python -m spacy download en"
+
+- name: create notebook, config and data dir
+  file: 
+    path: "{{ item }}"
+    state: directory
+    mode: 0777
+  with_items:
+    - "{{ notebook_folder }}"
+    - "/miniconda/envs/{{ conda_environment_name }}/.jupyter"
+    - "{{ logs_folder }}"
+
+- name: Get dataset
+  unarchive:
+    src: https://storage.googleapis.com/gdd-trainings-bucket/accelerator-lecture07_nlp-data.tar.gz
+    remote_src: yes
+    dest: "{{ notebook_folder }}"
+    creates: "{{ notebook_folder }}/data"
+
+- name: Configure jupyter notebook
+  template: 
+    src: jupyter_notebook_config.py 
+    dest: "/miniconda/envs/{{ conda_environment_name }}/.jupyter/"
+    mode: 0755
+
+- name: Copy jupyter start script
+  template: 
+    src: start-jupyter.sh
+    dest: "/miniconda/envs/{{ conda_environment_name }}"
+    mode: 0775
+
+- name: copy notebooks
+  copy:
+    src: files/notebooks/
+    dest: "{{ notebook_folder }}"
+    owner: "{{ deployer }}"
+    mode: 0777
+
+- name: Stop jupyter
+  shell: pkill jupyter
+  ignore_errors: yes
+
+- name: Start jupyter
+  become: no
+  shell: "nohup /miniconda/envs/{{ conda_environment_name }}/start-jupyter.sh >> {{ logs_folder }}/jupyter.log &"

--- a/elastic/roles/conda/templates/environment.yml
+++ b/elastic/roles/conda/templates/environment.yml
@@ -1,0 +1,14 @@
+name: {{ conda_environment_name }}
+dependencies:
+- elasticsearch=6.2.0
+- jupyter=1.0.0
+- pip=9.0.3
+- python=3.6.5
+- seaborn=0.8.1
+- scikit-learn=0.19.1
+- requests=2.18.4
+- pip:
+  - ijson==2.3
+  - pystemmer==1.3.0
+  - pyxdameraulevenshtein==1.5
+  - spacy==2.0.11

--- a/elastic/roles/conda/templates/environment.yml
+++ b/elastic/roles/conda/templates/environment.yml
@@ -1,13 +1,19 @@
 name: {{ conda_environment_name }}
+channels:
+  - damianavila82
+  - conda-forge
+  - defaults
 dependencies:
-- elasticsearch=6.2.0
 - jupyter=1.0.0
-- pip=9.0.3
-- python=3.6.5
+- pip=10.0.1
+- python=3.6.6
 - seaborn=0.8.1
 - scikit-learn=0.19.1
 - requests=2.18.4
+- rise=5.3.0
 - pip:
+  - elasticsearch==6.3.0
+  - elasticsearch-dsl==6.2.1
   - ijson==2.3
   - pystemmer==1.3.0
   - pyxdameraulevenshtein==1.5

--- a/elastic/roles/conda/templates/jupyter_notebook_config.py
+++ b/elastic/roles/conda/templates/jupyter_notebook_config.py
@@ -1,0 +1,581 @@
+# Configuration file for jupyter-notebook.
+
+#------------------------------------------------------------------------------
+# Application(SingletonConfigurable) configuration
+#------------------------------------------------------------------------------
+
+## This is an application.
+
+## The date format used by logging formatters for %(asctime)s
+#c.Application.log_datefmt = '%Y-%m-%d %H:%M:%S'
+
+## The Logging format template
+#c.Application.log_format = '[%(name)s]%(highlevel)s %(message)s'
+
+## Set the log level by value or name.
+#c.Application.log_level = 30
+
+#------------------------------------------------------------------------------
+# JupyterApp(Application) configuration
+#------------------------------------------------------------------------------
+
+## Base class for Jupyter applications
+
+## Answer yes to any prompts.
+#c.JupyterApp.answer_yes = False
+
+## Full path of a config file.
+#c.JupyterApp.config_file = u''
+
+## Specify a config file to load.
+#c.JupyterApp.config_file_name = u''
+
+## Generate default config file.
+#c.JupyterApp.generate_config = False
+
+#------------------------------------------------------------------------------
+# NotebookApp(JupyterApp) configuration
+#------------------------------------------------------------------------------
+
+## Set the Access-Control-Allow-Credentials: true header
+#c.NotebookApp.allow_credentials = False
+
+## Set the Access-Control-Allow-Origin header
+#  
+#  Use '*' to allow any origin to access your server.
+#  
+#  Takes precedence over allow_origin_pat.
+#c.NotebookApp.allow_origin = ''
+
+## Use a regular expression for the Access-Control-Allow-Origin header
+#  
+#  Requests from an origin matching the expression will get replies with:
+#  
+#      Access-Control-Allow-Origin: origin
+#  
+#  where `origin` is the origin of the request.
+#  
+#  Ignored if allow_origin is set.
+#c.NotebookApp.allow_origin_pat = ''
+
+## DEPRECATED use base_url
+#c.NotebookApp.base_project_url = '/'
+
+## The base URL for the notebook server.
+#  
+#  Leading and trailing slashes can be omitted, and will automatically be added.
+#c.NotebookApp.base_url = '/'
+
+## Specify what command to use to invoke a web browser when opening the notebook.
+#  If not specified, the default browser will be determined by the `webbrowser`
+#  standard library module, which allows setting of the BROWSER environment
+#  variable to override it.
+#c.NotebookApp.browser = u''
+
+## The full path to an SSL/TLS certificate file.
+#c.NotebookApp.certfile = u''
+
+## The full path to a certificate authority certificate for SSL/TLS client
+#  authentication.
+#c.NotebookApp.client_ca = u''
+
+## The config manager class to use
+#c.NotebookApp.config_manager_class = 'notebook.services.config.manager.ConfigManager'
+
+## The notebook manager class to use.
+#c.NotebookApp.contents_manager_class = 'notebook.services.contents.filemanager.FileContentsManager'
+
+## Extra keyword arguments to pass to `set_secure_cookie`. See tornado's
+#  set_secure_cookie docs for details.
+#c.NotebookApp.cookie_options = {}
+
+## The random bytes used to secure cookies. By default this is a new random
+#  number every time you start the Notebook. Set it to a value in a config file
+#  to enable logins to persist across server sessions.
+#  
+#  Note: Cookie secrets should be kept private, do not share config files with
+#  cookie_secret stored in plaintext (you can read the value from a file).
+#c.NotebookApp.cookie_secret = ''
+
+## The file where the cookie secret is stored.
+#c.NotebookApp.cookie_secret_file = u''
+
+## The default URL to redirect to from `/`
+#c.NotebookApp.default_url = '/tree'
+
+## Disable cross-site-request-forgery protection
+#  
+#  Jupyter notebook 4.3.1 introduces protection from cross-site request
+#  forgeries, requiring API requests to either:
+#  
+#  - originate from pages served by this server (validated with XSRF cookie and
+#  token), or - authenticate with a token
+#  
+#  Some anonymous compute resources still desire the ability to run code,
+#  completely without authentication. These services can disable all
+#  authentication and security checks, with the full knowledge of what that
+#  implies.
+#c.NotebookApp.disable_check_xsrf = False
+
+## Whether to enable MathJax for typesetting math/TeX
+#  
+#  MathJax is the javascript library Jupyter uses to render math/LaTeX. It is
+#  very large, so you may want to disable it if you have a slow internet
+#  connection, or for offline use of the notebook.
+#  
+#  When disabled, equations etc. will appear as their untransformed TeX source.
+#c.NotebookApp.enable_mathjax = True
+
+## extra paths to look for Javascript notebook extensions
+#c.NotebookApp.extra_nbextensions_path = []
+
+## Extra paths to search for serving static files.
+#  
+#  This allows adding javascript/css to be available from the notebook server
+#  machine, or overriding individual files in the IPython
+#c.NotebookApp.extra_static_paths = []
+
+## Extra paths to search for serving jinja templates.
+#  
+#  Can be used to override templates from notebook.templates.
+#c.NotebookApp.extra_template_paths = []
+
+## 
+#c.NotebookApp.file_to_run = ''
+
+## Use minified JS file or not, mainly use during dev to avoid JS recompilation
+#c.NotebookApp.ignore_minified_js = False
+
+## (bytes/sec) Maximum rate at which messages can be sent on iopub before they
+#  are limited.
+#c.NotebookApp.iopub_data_rate_limit = 0
+
+## (msg/sec) Maximum rate at which messages can be sent on iopub before they are
+#  limited.
+#c.NotebookApp.iopub_msg_rate_limit = 0
+
+## The IP address the notebook server will listen on.
+c.NotebookApp.ip = '0.0.0.0'
+
+## Supply extra arguments that will be passed to Jinja environment.
+#c.NotebookApp.jinja_environment_options = {}
+
+## Extra variables to supply to jinja templates when rendering.
+#c.NotebookApp.jinja_template_vars = {}
+
+## The kernel manager class to use.
+#c.NotebookApp.kernel_manager_class = 'notebook.services.kernels.kernelmanager.MappingKernelManager'
+
+## The kernel spec manager class to use. Should be a subclass of
+#  `jupyter_client.kernelspec.KernelSpecManager`.
+#  
+#  The Api of KernelSpecManager is provisional and might change without warning
+#  between this version of Jupyter and the next stable one.
+#c.NotebookApp.kernel_spec_manager_class = 'jupyter_client.kernelspec.KernelSpecManager'
+
+## The full path to a private key file for usage with SSL/TLS.
+#c.NotebookApp.keyfile = u''
+
+## The login handler class to use.
+#c.NotebookApp.login_handler_class = 'notebook.auth.login.LoginHandler'
+
+## The logout handler class to use.
+#c.NotebookApp.logout_handler_class = 'notebook.auth.logout.LogoutHandler'
+
+## A custom url for MathJax.js. Should be in the form of a case-sensitive url to
+#  MathJax, for example:  /static/components/MathJax/MathJax.js
+#c.NotebookApp.mathjax_url = ''
+
+## Dict of Python modules to load as notebook server extensions.Entry values can
+#  be used to enable and disable the loading ofthe extensions. The extensions
+#  will be loaded in alphabetical order.
+#c.NotebookApp.nbserver_extensions = {}
+
+## The directory to use for notebooks and kernels.
+c.NotebookApp.notebook_dir = u'{{ notebook_folder }}'
+
+## Whether to open in a browser after starting. The specific browser used is
+#  platform dependent and determined by the python standard library `webbrowser`
+#  module, unless it is overridden using the --browser (NotebookApp.browser)
+#  configuration option.
+#c.NotebookApp.open_browser = True
+
+## Hashed password to use for web authentication.
+#  
+#  To generate, type in a python/IPython shell:
+#  
+#    from notebook.auth import passwd; passwd()
+#  
+#  The string should be of the form type:salt:hashed-password.
+# c.NotebookApp.password = u'sha1:729816627d32:f1524845c014de347424e90954bda36110b06465'
+
+## The port the notebook server will listen on.
+c.NotebookApp.port = {{ notebook_port }}
+
+## The number of additional ports to try if the specified port is not available.
+#c.NotebookApp.port_retries = 50
+
+## DISABLED: use %pylab or %matplotlib in the notebook to enable matplotlib.
+#c.NotebookApp.pylab = 'disabled'
+
+## (sec) Time window used to  check the message and data rate limits.
+#c.NotebookApp.rate_limit_window = 1.0
+
+## Reraise exceptions encountered loading server extensions?
+#c.NotebookApp.reraise_server_extension_failures = False
+
+## DEPRECATED use the nbserver_extensions dict instead
+#c.NotebookApp.server_extensions = []
+
+## The session manager class to use.
+#c.NotebookApp.session_manager_class = 'notebook.services.sessions.sessionmanager.SessionManager'
+
+## Supply SSL options for the tornado HTTPServer. See the tornado docs for
+#  details.
+#c.NotebookApp.ssl_options = {}
+
+## Token used for authenticating first-time connections to the server.
+#  
+#  When no password is enabled, the default is to generate a new, random token.
+#  
+#  Setting to an empty string disables authentication altogether, which is NOT
+#  RECOMMENDED.
+c.NotebookApp.token = '{{ notebook_token }}'
+
+## Supply overrides for the tornado.web.Application that the Jupyter notebook
+#  uses.
+#c.NotebookApp.tornado_settings = {}
+
+## Whether to trust or not X-Scheme/X-Forwarded-Proto and X-Real-Ip/X-Forwarded-
+#  For headerssent by the upstream reverse proxy. Necessary if the proxy handles
+#  SSL
+#c.NotebookApp.trust_xheaders = False
+
+## DEPRECATED, use tornado_settings
+#c.NotebookApp.webapp_settings = {}
+
+## The base URL for websockets, if it differs from the HTTP server (hint: it
+#  almost certainly doesn't).
+#  
+#  Should be in the form of an HTTP origin: ws[s]://hostname[:port]
+#c.NotebookApp.websocket_url = ''
+
+#------------------------------------------------------------------------------
+# ConnectionFileMixin(LoggingConfigurable) configuration
+#------------------------------------------------------------------------------
+
+## Mixin for configurable classes that work with connection files
+
+## JSON file in which to store connection info [default: kernel-<pid>.json]
+#  
+#  This file will contain the IP, ports, and authentication key needed to connect
+#  clients to this kernel. By default, this file will be created in the security
+#  dir of the current profile, but can be specified by absolute path.
+#c.ConnectionFileMixin.connection_file = ''
+
+## set the control (ROUTER) port [default: random]
+#c.ConnectionFileMixin.control_port = 0
+
+## set the heartbeat port [default: random]
+#c.ConnectionFileMixin.hb_port = 0
+
+## set the iopub (PUB) port [default: random]
+#c.ConnectionFileMixin.iopub_port = 0
+
+## Set the kernel's IP address [default localhost]. If the IP address is
+#  something other than localhost, then Consoles on other machines will be able
+#  to connect to the Kernel, so be careful!
+#c.ConnectionFileMixin.ip = u''
+
+## set the shell (ROUTER) port [default: random]
+#c.ConnectionFileMixin.shell_port = 0
+
+## set the stdin (ROUTER) port [default: random]
+#c.ConnectionFileMixin.stdin_port = 0
+
+## 
+#c.ConnectionFileMixin.transport = 'tcp'
+
+#------------------------------------------------------------------------------
+# KernelManager(ConnectionFileMixin) configuration
+#------------------------------------------------------------------------------
+
+## Manages a single kernel in a subprocess on this host.
+#  
+#  This version starts kernels with Popen.
+
+## Should we autorestart the kernel if it dies.
+#c.KernelManager.autorestart = True
+
+## DEPRECATED: Use kernel_name instead.
+#  
+#  The Popen Command to launch the kernel. Override this if you have a custom
+#  kernel. If kernel_cmd is specified in a configuration file, Jupyter does not
+#  pass any arguments to the kernel, because it cannot make any assumptions about
+#  the arguments that the kernel understands. In particular, this means that the
+#  kernel does not receive the option --debug if it given on the Jupyter command
+#  line.
+#c.KernelManager.kernel_cmd = []
+
+#------------------------------------------------------------------------------
+# Session(Configurable) configuration
+#------------------------------------------------------------------------------
+
+## Object for handling serialization and sending of messages.
+#  
+#  The Session object handles building messages and sending them with ZMQ sockets
+#  or ZMQStream objects.  Objects can communicate with each other over the
+#  network via Session objects, and only need to work with the dict-based IPython
+#  message spec. The Session will handle serialization/deserialization, security,
+#  and metadata.
+#  
+#  Sessions support configurable serialization via packer/unpacker traits, and
+#  signing with HMAC digests via the key/keyfile traits.
+#  
+#  Parameters ----------
+#  
+#  debug : bool
+#      whether to trigger extra debugging statements
+#  packer/unpacker : str : 'json', 'pickle' or import_string
+#      importstrings for methods to serialize message parts.  If just
+#      'json' or 'pickle', predefined JSON and pickle packers will be used.
+#      Otherwise, the entire importstring must be used.
+#  
+#      The functions must accept at least valid JSON input, and output *bytes*.
+#  
+#      For example, to use msgpack:
+#      packer = 'msgpack.packb', unpacker='msgpack.unpackb'
+#  pack/unpack : callables
+#      You can also set the pack/unpack callables for serialization directly.
+#  session : bytes
+#      the ID of this Session object.  The default is to generate a new UUID.
+#  username : unicode
+#      username added to message headers.  The default is to ask the OS.
+#  key : bytes
+#      The key used to initialize an HMAC signature.  If unset, messages
+#      will not be signed or checked.
+#  keyfile : filepath
+#      The file containing a key.  If this is set, `key` will be initialized
+#      to the contents of the file.
+
+## Threshold (in bytes) beyond which an object's buffer should be extracted to
+#  avoid pickling.
+#c.Session.buffer_threshold = 1024
+
+## Whether to check PID to protect against calls after fork.
+#  
+#  This check can be disabled if fork-safety is handled elsewhere.
+#c.Session.check_pid = True
+
+## Threshold (in bytes) beyond which a buffer should be sent without copying.
+#c.Session.copy_threshold = 65536
+
+## Debug output in the Session
+#c.Session.debug = False
+
+## The maximum number of digests to remember.
+#  
+#  The digest history will be culled when it exceeds this value.
+#c.Session.digest_history_size = 65536
+
+## The maximum number of items for a container to be introspected for custom
+#  serialization. Containers larger than this are pickled outright.
+#c.Session.item_threshold = 64
+
+## execution key, for signing messages.
+#c.Session.key = ''
+
+## path to file containing execution key.
+#c.Session.keyfile = ''
+
+## Metadata dictionary, which serves as the default top-level metadata dict for
+#  each message.
+#c.Session.metadata = {}
+
+## The name of the packer for serializing messages. Should be one of 'json',
+#  'pickle', or an import name for a custom callable serializer.
+#c.Session.packer = 'json'
+
+## The UUID identifying this session.
+#c.Session.session = u''
+
+## The digest scheme used to construct the message signatures. Must have the form
+#  'hmac-HASH'.
+#c.Session.signature_scheme = 'hmac-sha256'
+
+## The name of the unpacker for unserializing messages. Only used with custom
+#  functions for `packer`.
+#c.Session.unpacker = 'json'
+
+## Username for the Session. Default is your system username.
+#c.Session.username = u'kgeusebroek'
+
+#------------------------------------------------------------------------------
+# MultiKernelManager(LoggingConfigurable) configuration
+#------------------------------------------------------------------------------
+
+## A class for managing multiple kernels.
+
+## The name of the default kernel to start
+#c.MultiKernelManager.default_kernel_name = 'python2'
+
+## The kernel manager class.  This is configurable to allow subclassing of the
+#  KernelManager for customized behavior.
+#c.MultiKernelManager.kernel_manager_class = 'jupyter_client.ioloop.IOLoopKernelManager'
+
+#------------------------------------------------------------------------------
+# MappingKernelManager(MultiKernelManager) configuration
+#------------------------------------------------------------------------------
+
+## A KernelManager that handles notebook mapping and HTTP error handling
+
+## 
+#c.MappingKernelManager.root_dir = u''
+
+#------------------------------------------------------------------------------
+# ContentsManager(LoggingConfigurable) configuration
+#------------------------------------------------------------------------------
+
+## Base class for serving files and directories.
+#  
+#  This serves any text or binary file, as well as directories, with special
+#  handling for JSON notebook documents.
+#  
+#  Most APIs take a path argument, which is always an API-style unicode path, and
+#  always refers to a directory.
+#  
+#  - unicode, not url-escaped
+#  - '/'-separated
+#  - leading and trailing '/' will be stripped
+#  - if unspecified, path defaults to '',
+#    indicating the root path.
+
+## 
+#c.ContentsManager.checkpoints = None
+
+## 
+#c.ContentsManager.checkpoints_class = 'notebook.services.contents.checkpoints.Checkpoints'
+
+## 
+#c.ContentsManager.checkpoints_kwargs = {}
+
+## Glob patterns to hide in file and directory listings.
+#c.ContentsManager.hide_globs = [u'__pycache__', '*.pyc', '*.pyo', '.DS_Store', '*.so', '*.dylib', '*~']
+
+## Python callable or importstring thereof
+#  
+#  To be called on a contents model prior to save.
+#  
+#  This can be used to process the structure, such as removing notebook outputs
+#  or other side effects that should not be saved.
+#  
+#  It will be called as (all arguments passed by keyword)::
+#  
+#      hook(path=path, model=model, contents_manager=self)
+#  
+#  - model: the model to be saved. Includes file contents.
+#    Modifying this dict will affect the file that is stored.
+#  - path: the API path of the save destination
+#  - contents_manager: this ContentsManager instance
+#c.ContentsManager.pre_save_hook = None
+
+## The base name used when creating untitled directories.
+#c.ContentsManager.untitled_directory = 'Untitled Folder'
+
+## The base name used when creating untitled files.
+#c.ContentsManager.untitled_file = 'untitled'
+
+## The base name used when creating untitled notebooks.
+#c.ContentsManager.untitled_notebook = 'Untitled'
+
+#------------------------------------------------------------------------------
+# FileManagerMixin(Configurable) configuration
+#------------------------------------------------------------------------------
+
+## Mixin for ContentsAPI classes that interact with the filesystem.
+#  
+#  Provides facilities for reading, writing, and copying both notebooks and
+#  generic files.
+#  
+#  Shared by FileContentsManager and FileCheckpoints.
+#  
+#  Note ---- Classes using this mixin must provide the following attributes:
+#  
+#  root_dir : unicode
+#      A directory against against which API-style paths are to be resolved.
+#  
+#  log : logging.Logger
+
+## By default notebooks are saved on disk on a temporary file and then if
+#  succefully written, it replaces the old ones. This procedure, namely
+#  'atomic_writing', causes some bugs on file system whitout operation order
+#  enforcement (like some networked fs). If set to False, the new notebook is
+#  written directly on the old one which could fail (eg: full filesystem or quota
+#  )
+#c.FileManagerMixin.use_atomic_writing = True
+
+#------------------------------------------------------------------------------
+# FileContentsManager(FileManagerMixin,ContentsManager) configuration
+#------------------------------------------------------------------------------
+
+## Python callable or importstring thereof
+#  
+#  to be called on the path of a file just saved.
+#  
+#  This can be used to process the file on disk, such as converting the notebook
+#  to a script or HTML via nbconvert.
+#  
+#  It will be called as (all arguments passed by keyword)::
+#  
+#      hook(os_path=os_path, model=model, contents_manager=instance)
+#  
+#  - path: the filesystem path to the file just written - model: the model
+#  representing the file - contents_manager: this ContentsManager instance
+#c.FileContentsManager.post_save_hook = None
+
+## 
+#c.FileContentsManager.root_dir = u''
+
+## DEPRECATED, use post_save_hook. Will be removed in Notebook 5.0
+#c.FileContentsManager.save_script = False
+
+#------------------------------------------------------------------------------
+# NotebookNotary(LoggingConfigurable) configuration
+#------------------------------------------------------------------------------
+
+## A class for computing and verifying notebook signatures.
+
+## The hashing algorithm used to sign notebooks.
+#c.NotebookNotary.algorithm = 'sha256'
+
+## The number of notebook signatures to cache. When the number of signatures
+#  exceeds this value, the oldest 25% of signatures will be culled.
+#c.NotebookNotary.cache_size = 65535
+
+## The sqlite file in which to store notebook signatures. By default, this will
+#  be in your Jupyter data directory. You can set it to ':memory:' to disable
+#  sqlite writing to the filesystem.
+#c.NotebookNotary.db_file = u''
+
+## The secret key with which notebooks are signed.
+#c.NotebookNotary.secret = ''
+
+## The file where the secret key is stored.
+#c.NotebookNotary.secret_file = u''
+
+#------------------------------------------------------------------------------
+# KernelSpecManager(LoggingConfigurable) configuration
+#------------------------------------------------------------------------------
+
+## If there is no Python kernelspec registered and the IPython kernel is
+#  available, ensure it is added to the spec list.
+#c.KernelSpecManager.ensure_native_kernel = True
+
+## The kernel spec class.  This is configurable to allow subclassing of the
+#  KernelSpecManager for customized behavior.
+#c.KernelSpecManager.kernel_spec_class = 'jupyter_client.kernelspec.KernelSpec'
+
+## Whitelist of allowed kernel names.
+#  
+#  By default, all installed kernels are allowed.
+#c.KernelSpecManager.whitelist = set([])

--- a/elastic/roles/conda/templates/start-jupyter.sh
+++ b/elastic/roles/conda/templates/start-jupyter.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source /miniconda/bin/activate {{ conda_environment_name }}
+
+export PATH=/miniconda/envs/{{ conda_environment_name }}/bin:$PATH
+
+exec /miniconda/envs/{{ conda_environment_name }}/bin/jupyter notebook --config /miniconda/envs/{{ conda_environment_name }}/.jupyter/jupyter_notebook_config.py &> /dev/null &

--- a/elastic/roles/elastic/tasks/main.yml
+++ b/elastic/roles/elastic/tasks/main.yml
@@ -18,6 +18,7 @@
     - "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{ elastic_version }}.deb"
     - "https://artifacts.elastic.co/downloads/kibana/kibana-{{ elastic_version }}-amd64.deb"
     - "https://artifacts.elastic.co/downloads/logstash/logstash-{{ elastic_version }}.deb"
+    - "https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-{{ elastic_version }}-amd64.deb"
 
 - name: Set elasticsearch host to internal IP
   lineinfile:
@@ -43,6 +44,7 @@
     - elasticsearch.service
     - kibana.service
     - logstash.service
+    - filebeat.service
 
 - name: change ownership of original services directories
   file:
@@ -53,6 +55,7 @@
     - "elasticsearch"
     - "kibana"
     - "logstash"
+    - "filebeat"
 
 - name: create services directory
   file:
@@ -71,4 +74,10 @@
     - "elasticsearch"
     - "kibana"
     - "logstash"
+    - "filebeat"
 
+- name: change ownership of logs directory so student can write to it
+  file:
+    path: "/var/log"
+    mode: 0777
+    recurse: yes

--- a/elastic/roles/elastic/tasks/main.yml
+++ b/elastic/roles/elastic/tasks/main.yml
@@ -1,0 +1,74 @@
+- name: Install java
+  apt: 
+    name: "{{ item }}"
+    state: latest
+  with_items:
+    - openjdk-8-jdk
+
+- name: Make Java8 the default
+  alternatives:
+    name: java
+    path: /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+
+- name: Install needed deb packages
+  apt: 
+    deb: "{{ item }}"
+    state: present
+  with_items:
+    - "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-{{ elastic_version }}.deb"
+    - "https://artifacts.elastic.co/downloads/kibana/kibana-{{ elastic_version }}-amd64.deb"
+    - "https://artifacts.elastic.co/downloads/logstash/logstash-{{ elastic_version }}.deb"
+
+- name: Set elasticsearch host to internal IP
+  lineinfile:
+    dest: /etc/elasticsearch/elasticsearch.yml
+    state: present
+    regexp: "^network\\.host"
+    line: "network.host: 0.0.0.0"
+
+- name: Set kibana server host to internal IP
+  lineinfile:
+    dest: /etc/kibana/kibana.yml
+    state: present
+    regexp: "^server\\.host"
+    line: "server.host: {{ hostvars[inventory_hostname]['ansible_default_ipv4']['address'] }}"
+
+- name: restart and enable service, also issue daemon-reload to pick up config changes
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    enabled: yes
+    name: "{{ item }}"
+  with_items:
+    - elasticsearch.service
+    - kibana.service
+    - logstash.service
+
+- name: change ownership of original services directories
+  file:
+    path: "/etc/{{ item }}"
+    mode: 0777
+    recurse: yes
+  with_items:
+    - "elasticsearch"
+    - "kibana"
+    - "logstash"
+
+- name: create services directory
+  file:
+    path: "{{ notebook_folder }}/services"
+    state: directory
+    mode: 0777
+
+- name: make symlinks to service directories
+  file:
+    src: "/etc/{{ item }}"
+    dest: "{{ notebook_folder }}/services/{{ item }}"
+    mode: 0777
+    state: link
+    force: yes
+  with_items:
+    - "elasticsearch"
+    - "kibana"
+    - "logstash"
+

--- a/elastic/vars/common.yml
+++ b/elastic/vars/common.yml
@@ -1,8 +1,8 @@
 deployer: deploy
 users:
-  - kris
-  - robert
-elastic_version: 6.3.1
+  - student00
+  - student01
+elastic_version: 6.4.0
 notebook_folder: /training/notebooks
 notebook_port: 5000
 logs_folder: /training/logs

--- a/elastic/vars/common.yml
+++ b/elastic/vars/common.yml
@@ -1,0 +1,10 @@
+deployer: deploy
+users:
+  - kris
+  - robert
+elastic_version: 6.3.1
+notebook_folder: /training/notebooks
+notebook_port: 5000
+logs_folder: /training/logs
+notebook_token: class-elastic
+conda_environment_name: godatadriven_elastic


### PR DESCRIPTION
This PR creates a subdirectory called `elastic/` in the root directory, which contains a version of the already-existing `nlp/` subdirectory, modified for Elastic Stack trainings (Elasticsearch, Logstash, Kibana, Filebeat).